### PR TITLE
Fix npm executing on windows, spawn of npm fails with ENOENT

### DIFF
--- a/zelda.js
+++ b/zelda.js
@@ -163,9 +163,10 @@ function zelda (root, done) {
 
 function npmInstall (cwd, cb) {
   var pkgName = path.basename(cwd)
+  var npmExecutable = process.platform === 'win32' ? 'npm.cmd' : 'npm'
   console.log('NPM INSTALL: ' + pkgName, cwd)
 
-  var child = cp.spawn('npm', ['install'], { cwd: cwd, stdio: 'inherit' })
+  var child = cp.spawn(npmExecutable, ['install'], { cwd: cwd, stdio: 'inherit' })
 
   child.on('exit', function () {
     cb(null)


### PR DESCRIPTION
zelda fails to invoke npm install on windows.

The underlying [issue](https://github.com/joyent/node/issues/2318) is node's executable resolving algorithm, which I in doubt will be fixed soon.

More about it [here](http://stackoverflow.com/questions/17516772/using-nodejss-spawn-causes-unknown-option-and-error-spawn-enoent-err#answer-17537559). 

Other possible fix is to [replace spawn with exec](https://github.com/yurynix/zelda/tree/feature/replace-spawn-with-exec), but that'll ruin npm's color output.
