### PR TITLE
Fix symlink creation on Windows Issue #10

### DIFF
--- a/zelda.js
+++ b/zelda.js
@@ -141,7 +141,7 @@ function zelda (root, done) {
       }
 
       try {
-        fs.symlinkSync(src, dst)
+        fs.symlinkSync(src, dst, 'dir')
         console.log('NPM LINK: ' + dst + ' => ' + src)
       } catch (e) {
         console.log('using existing symlink... ' + dst)


### PR DESCRIPTION
Fixes #10

On Windows 8.1 I was running in to an issue with the symbolic links created by Zelda. 

Within my `node_modules` folder `<package>.symlink` *files* were being created instead of the expected *folder* symlinks.

Doing some searching led me to https://github.com/joyent/node/issues/2274, which pointed me towards the documentation here: 
https://nodejs.org/api/fs.html#fs_fs_symlink_srcpath_dstpath_type_callback

It looks like if on Windows specifying the `type` parameter `'dir'` to `fs.symlinkSync` is necessary for the right kind of link to be created. For non-Windows platforms this `type` parameter is ignored. 