### PR TITLE
Start purging linked modules from the current project directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,10 +57,10 @@ function zelda (rootPath, opts) {
     if (opts.install && pkgToPurge !== rootName) {
       npmInstall(pkgPath, opts.production)
     }
+  })
 
-    traverseNodeModules(pkgPath, function (pkgName, pkgPath) {
-      if (pkgsToPurge[pkgName]) rimraf.sync(pkgPath)
-    })
+  traverseNodeModules(rootPath, function (pkgName, pkgPath) {
+    if (pkgsToPurge[pkgName]) rimraf.sync(pkgPath)
   })
 }
 


### PR DESCRIPTION
Right now only the modules within a linked module are purged:

- /workspace/project1
- /workspace/project2

`cd project1 && zelda` will only purge modules inside project2, this means that project1 will still have an installed project2 reference

This PR should fix that by starting the purge from the current project (project1)