### PR TITLE
Remove local packages from top level (useful in microservices)

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ function zelda (rootPath, opts) {
         // Check for the packages existence
         fs.readdirSync(`${codePath}/${pkgOuter}/node_modules/${pkgInner}`)
         console.log(`Removing '${pkgInner}' from ${codePath}/${pkgOuter}`)
-        rimraf.sync(`${codePath}/${pkgInner}/node_modules/${pkgOuter}`)
+        rimraf.sync(`${codePath}/${pkgOuter}/node_modules/${pkgInner}`)
       } catch (err) {
         // Nothing to error out on here
       }

--- a/index.js
+++ b/index.js
@@ -62,6 +62,22 @@ function zelda (rootPath, opts) {
   traverseNodeModules(rootPath, function (pkgName, pkgPath) {
     if (pkgsToPurge[pkgName]) rimraf.sync(pkgPath)
   })
+
+  // Outer loop of packages to purge
+  Object.keys(pkgsToPurge).map(function (pkgOuter) {
+    // Inner loop of packages to purge
+    Object.keys(pkgsToPurge).map(function (pkgInner) {
+      try {
+        // Check for the packages existence
+        fs.readdirSync(`${codePath}/${pkgOuter}/node_modules/${pkgInner}`)
+        console.log(`Removing '${pkgInner}' from ${codePath}/${pkgOuter}`)
+        rimraf.sync(`${codePath}/${pkgInner}/node_modules/${pkgOuter}`)
+      } catch (err) {
+        // Nothing to error out on here
+      }
+    })
+  })
+
 }
 
 function getCodePkgs (codePath) {

--- a/index.js
+++ b/index.js
@@ -77,7 +77,6 @@ function zelda (rootPath, opts) {
       }
     })
   })
-
 }
 
 function getCodePkgs (codePath) {


### PR DESCRIPTION
This PR adds an additional step at the end of the whole run to check the top level modules for local packages. This is useful where you have many `npm` packages locally that are included in other local packages... for example if you have a `config` package that is included in multiple other packages which in turn are included elsewhere. We have found this to ease development of our micro-service style architecture. Without it we end up with some packages - that are local - installed directly from GitHub or npm.